### PR TITLE
[codex] Fix Outlook wrapper login and deb builds

### DIFF
--- a/apps/outlook/config.json
+++ b/apps/outlook/config.json
@@ -17,6 +17,7 @@
     "clipboard-read",
     "clipboard-write"
   ],
+  "preserveWebSecurityHeaders": true,
   "snapName": "outlook-ew",
   "snapDescription": "Microsoft Outlook web wrapper for Linux",
   "desktopName": "Microsoft Outlook",

--- a/build.js
+++ b/build.js
@@ -1,8 +1,17 @@
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync, execSync } = require('child_process');
 
 const appName = process.argv[2] || 'teams';
+const targetArgIndex = process.argv.indexOf('--target');
+const buildTarget = targetArgIndex >= 0
+  ? process.argv[targetArgIndex + 1]
+  : (process.env.BUILD_TARGET || 'snap');
+const supportedBuildTargets = new Set(['snap', 'deb', 'AppImage']);
+if (!supportedBuildTargets.has(buildTarget)) {
+  console.error(`Unsupported build target "${buildTarget}". Use one of: ${Array.from(supportedBuildTargets).join(', ')}`);
+  process.exit(1);
+}
 const appDir = path.join(__dirname, 'apps', appName);
 
 // Safe recursive copy to avoid shelling out (prevents command injection)
@@ -31,6 +40,11 @@ if (!fs.existsSync(appDir)) {
 const buildDir = path.join(__dirname, 'build', appName);
 if (!fs.existsSync(buildDir)) {
   fs.mkdirSync(buildDir, { recursive: true });
+}
+
+function runElectronBuilder(args) {
+  const electronBuilderCli = path.join(buildDir, 'node_modules', 'electron-builder', 'out', 'cli', 'cli.js');
+  execFileSync(process.execPath, [electronBuilderCli, ...args], { cwd: buildDir, stdio: 'inherit' });
 }
 
 // Copy source files to build directory
@@ -103,21 +117,32 @@ try {
   process.exit(1);
 }
 
-console.log(`Building snap for ${appName}...`);
-try {
-  // Use snapcraft directly for better control
-  execSync('snapcraft --destructive-mode', { cwd: buildDir, stdio: 'inherit' });
-} catch (error) {
-  console.error('Snap build failed:', error.message);
-  // Try electron-builder as fallback
-  console.log('Trying electron-builder as fallback...');
+console.log(`Building ${buildTarget} package for ${appName}...`);
+if (buildTarget === 'snap') {
   try {
-    execSync('electron-builder --linux snap', { cwd: buildDir, stdio: 'inherit' });
+    // Use snapcraft directly for better control
+    execSync('snapcraft --destructive-mode', { cwd: buildDir, stdio: 'inherit' });
+  } catch (error) {
+    console.error('Snap build failed:', error.message);
+    // Try electron-builder as fallback
+    console.log('Trying electron-builder as fallback...');
+    try {
+      runElectronBuilder(['--linux', 'snap']);
+    } catch (builderError) {
+      console.error('Electron-builder also failed:', builderError.message);
+      process.exit(1);
+    }
+  }
+} else {
+  try {
+    runElectronBuilder(['--linux', buildTarget]);
   } catch (builderError) {
-    console.error('Electron-builder also failed:', builderError.message);
+    console.error(`Electron-builder failed for target "${buildTarget}":`, builderError.message);
     process.exit(1);
   }
 }
 
-console.log(`Build complete! Check ${buildDir} for the snap file`);
-console.log(`To install it locally, run: sudo snap install ${path.join(buildDir, '*.snap')} --dangerous`);
+console.log(`Build complete! Check ${path.join(buildDir, 'dist')} and ${buildDir} for generated packages.`);
+if (buildTarget === 'snap') {
+  console.log(`To install it locally, run: sudo snap install ${path.join(buildDir, '*.snap')} --dangerous`);
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "run:spotify": "npx electron /apps/spotify",
     "build:teams": "node build.js teams",
     "build:outlook": "node build.js outlook",
+    "build:outlook:deb": "node build.js outlook --target deb",
+    "build:outlook:appimage": "node build.js outlook --target AppImage",
     "build:spotify": "node build.js spotify",
     "dev:teams": "node dev-run.js teams",
     "dev:outlook": "node dev-run.js outlook",

--- a/src/main.js
+++ b/src/main.js
@@ -221,6 +221,7 @@ if (process.platform === 'linux') {
 app.name = appConfig.name;
 
 const {isSnap} = applyEnvironment(app, appConfig);
+const preserveWebSecurityHeaders = appConfig.preserveWebSecurityHeaders === true;
 
 const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
@@ -365,17 +366,19 @@ if (!gotTheLock) {
 
             const targetSession = mainWindow.webContents.session;
 
-            targetSession.webRequest.onBeforeSendHeaders(
-                (details, callback) => {
-                    const url = details.url;
-                    // Only override Origin and Referer for Microsoft-related requests to avoid ERR_BLOCKED_BY_RESPONSE
-                    if (url.includes('microsoft.com') || url.includes('office.com') || url.includes('office365.com') || url.includes('live.com') || url.includes('msftauth.net') || url.includes('msauth.net')) {
-                        details.requestHeaders['Origin'] = appConfig.url;
-                        details.requestHeaders['Referer'] = appConfig.url;
+            if (!preserveWebSecurityHeaders) {
+                targetSession.webRequest.onBeforeSendHeaders(
+                    (details, callback) => {
+                        const url = details.url;
+                        // Only override Origin and Referer for Microsoft-related requests to avoid ERR_BLOCKED_BY_RESPONSE
+                        if (url.includes('microsoft.com') || url.includes('office.com') || url.includes('office365.com') || url.includes('live.com') || url.includes('msftauth.net') || url.includes('msauth.net')) {
+                            details.requestHeaders['Origin'] = appConfig.url;
+                            details.requestHeaders['Referer'] = appConfig.url;
+                        }
+                        callback({requestHeaders: details.requestHeaders});
                     }
-                    callback({requestHeaders: details.requestHeaders});
-                }
-            );
+                );
+            }
 
             mainWindow.webContents.setUserAgent(appConfig.userAgent);
             mainWindow.webContents.session.setPermissionRequestHandler((webContents, permission, callback) => {
@@ -407,30 +410,32 @@ if (!gotTheLock) {
                 }
             });
 
-            mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-                const responseHeaders = { ...details.responseHeaders };
-                // Remove existing CSP, X-Frame-Options, and COOP/CORP to avoid conflicts
-                Object.keys(responseHeaders).forEach(key => {
-                    const lowerKey = key.toLowerCase();
-                    if (lowerKey === 'content-security-policy' || 
-                        lowerKey === 'x-frame-options' || 
-                        lowerKey === 'cross-origin-opener-policy' ||
-                        lowerKey === 'cross-origin-resource-policy') {
-                        delete responseHeaders[key];
-                    }
-                });
+            if (!preserveWebSecurityHeaders) {
+                mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+                    const responseHeaders = { ...details.responseHeaders };
+                    // Remove existing CSP, X-Frame-Options, and COOP/CORP to avoid conflicts
+                    Object.keys(responseHeaders).forEach(key => {
+                        const lowerKey = key.toLowerCase();
+                        if (lowerKey === 'content-security-policy' ||
+                            lowerKey === 'x-frame-options' ||
+                            lowerKey === 'cross-origin-opener-policy' ||
+                            lowerKey === 'cross-origin-resource-policy') {
+                            delete responseHeaders[key];
+                        }
+                    });
 
-                callback({
-                    responseHeaders: {
-                        ...responseHeaders,
-                        'Content-Security-Policy': [
-                            "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
-                            "frame-ancestors 'self' https://*.microsoft.com https://*.office.com; " +
-                            "base-uri 'self';"
-                        ]
-                    }
+                    callback({
+                        responseHeaders: {
+                            ...responseHeaders,
+                            'Content-Security-Policy': [
+                                "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
+                                "frame-ancestors 'self' https://*.microsoft.com https://*.office.com; " +
+                                "base-uri 'self';"
+                            ]
+                        }
+                    });
                 });
-            });
+            }
 
             mainWindow.loadURL(appConfig.url, {
                 userAgent: appConfig.userAgent,
@@ -693,32 +698,34 @@ if (!gotTheLock) {
             // Setup enhanced memory management
             setupEnhancedMemoryManagement();
 
-            // Enhanced security headers
-            session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-                const responseHeaders = { ...details.responseHeaders };
-                // Remove existing CSP, X-Frame-Options, and COOP/CORP to avoid conflicts
-                Object.keys(responseHeaders).forEach(key => {
-                    const lowerKey = key.toLowerCase();
-                    if (lowerKey === 'content-security-policy' || 
-                        lowerKey === 'x-frame-options' || 
-                        lowerKey === 'cross-origin-opener-policy' ||
-                        lowerKey === 'cross-origin-resource-policy') {
-                        delete responseHeaders[key];
-                    }
-                });
+            if (!preserveWebSecurityHeaders) {
+                // Enhanced security headers
+                session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+                    const responseHeaders = { ...details.responseHeaders };
+                    // Remove existing CSP, X-Frame-Options, and COOP/CORP to avoid conflicts
+                    Object.keys(responseHeaders).forEach(key => {
+                        const lowerKey = key.toLowerCase();
+                        if (lowerKey === 'content-security-policy' ||
+                            lowerKey === 'x-frame-options' ||
+                            lowerKey === 'cross-origin-opener-policy' ||
+                            lowerKey === 'cross-origin-resource-policy') {
+                            delete responseHeaders[key];
+                        }
+                    });
 
-                callback({
-                    responseHeaders: {
-                        ...responseHeaders,
-                        'Content-Security-Policy': [
-                            "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
-                            "frame-ancestors 'self' https://*.microsoft.com https://*.office.com; " +
-                            "base-uri 'self';"
-                        ],
-                        'X-Content-Type-Options': ['nosniff']
-                    }
+                    callback({
+                        responseHeaders: {
+                            ...responseHeaders,
+                            'Content-Security-Policy': [
+                                "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
+                                "frame-ancestors 'self' https://*.microsoft.com https://*.office.com; " +
+                                "base-uri 'self';"
+                            ],
+                            'X-Content-Type-Options': ['nosniff']
+                        }
+                    });
                 });
-            });
+            }
 
             await session.defaultSession.clearCache();
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -1,6 +1,18 @@
 try {
   const { contextBridge, ipcRenderer } = require('electron');
-  const { allowedChannels } = require(require('path').resolve(__dirname, '..', 'security', 'ipcValidator.js'));
+  const allowedChannels = new Set([
+    'new-notification',
+    'preload-executed',
+    'zoom-change',
+    'trigger-screen-share',
+    'screen-sharing-stopped',
+    'screen-sharing-source-selected',
+    'screen-sharing-status-changed',
+    'get-screen-sharing-status',
+    'get-screen-share-stream',
+    'get-screen-share-screen',
+    'desktop-capturer-get-sources',
+  ]);
 
   contextBridge.exposeInMainWorld('api', {
     send: (channel, data) => {

--- a/src/security/ipcValidator.js
+++ b/src/security/ipcValidator.js
@@ -14,10 +14,13 @@ const allowedChannels = new Set([
   'get-app-version',
   
   // Zoom and display controls
+  'zoom-change',
+  'preload-executed',
   'get-zoom-level',
   'save-zoom-level',
   
   // Screen sharing and desktop capture - New secure implementation
+  'get-screen-sources-safe',
   'desktop-capturer-get-sources',
   'choose-desktop-media',
   'cancel-desktop-media',


### PR DESCRIPTION
## Summary
- add a configurable build target so the Outlook wrapper can build a deb/AppImage without requiring snapcraft
- let the Outlook wrapper preserve Microsoft's current response headers instead of replacing CSP/frame headers
- fix sandboxed preload startup by avoiding unsupported Node built-ins and allowlisting the IPC channels it uses

## Why
Current Outlook Web login and app boot can fail because the wrapper replaces Microsoft's CSP and request headers. Outlook now loads required assets and auth bridge code from Microsoft CDN origins that were blocked by the custom CSP. In Electron 35, the sandboxed preload also cannot resolve Node's path module, so the preload logs a module-not-found error.

## Scope
The header behavior is opt-in via the Outlook config (`preserveWebSecurityHeaders: true`) so existing non-Outlook wrappers keep the previous behavior.

## Validation
- `node --check build.js src/main.js src/preload/index.js src/security/ipcValidator.js`
- `npm run build:outlook:deb`
- local smoke test on Ubuntu 24.04 Wayland: Outlook window loaded and reached Microsoft login without the previous preload/CSP errors

## Notes
`npm install` reports one high-severity dev/build dependency audit issue; runtime dependencies report clean with `npm audit --omit=dev`.
