### PR TITLE
Fix broken re-authentication after session expiry

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -370,7 +370,8 @@ if (!gotTheLock) {
                     const url = details.url;
                     // Only override Origin and Referer for Microsoft-related requests to avoid ERR_BLOCKED_BY_RESPONSE
                     if (url.includes('microsoft.com') || url.includes('office.com') || url.includes('office365.com') || url.includes('live.com') || url.includes('msftauth.net') || url.includes('msauth.net')) {
-                        details.requestHeaders['Origin'] = appConfig.url;
+                        // Origin must be scheme://host only (no path), otherwise MS auth endpoints reject the request
+                        details.requestHeaders['Origin'] = new URL(appConfig.url).origin;
                         details.requestHeaders['Referer'] = appConfig.url;
                     }
                     callback({requestHeaders: details.requestHeaders});
@@ -424,8 +425,8 @@ if (!gotTheLock) {
                     responseHeaders: {
                         ...responseHeaders,
                         'Content-Security-Policy': [
-                            "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
-                            "frame-ancestors 'self' https://*.microsoft.com https://*.office.com; " +
+                            "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
+                            "frame-ancestors 'self' https://*.microsoft https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.msauth.net https://*.msftauth.net; " +
                             "base-uri 'self';"
                         ]
                     }
@@ -711,8 +712,8 @@ if (!gotTheLock) {
                     responseHeaders: {
                         ...responseHeaders,
                         'Content-Security-Policy': [
-                            "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
-                            "frame-ancestors 'self' https://*.microsoft.com https://*.office.com; " +
+                            "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
+                            "frame-ancestors 'self' https://*.microsoft https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.msauth.net https://*.msftauth.net; " +
                             "base-uri 'self';"
                         ],
                         'X-Content-Type-Options': ['nosniff']


### PR DESCRIPTION
When the session expired, no sign-in window appeared and the app became unresponsive. The forced CSP rewrite (and a malformed Origin header) were blocking Microsoft's authentication flow.

- default-src / frame-ancestors: allow the `.microsoft` gTLD (res.public.onecdn.static.microsoft), which now serves the OWA runtime and the MSAL auth scripts (owa.mail.runtime.js, owa.MsalAuth.js, msal-redirect-bridge.js). These were refused by the injected CSP, so both the app and the login UI failed to load.
- frame-ancestors: add the auth domains (microsoftonline.com, msauth.net, msftauth.net, live.com, office365.com) so nested sign-in iframes are no longer refused.
- Origin header: send scheme://host only. It was set to the full config URL (https://outlook.office.com/mail/); an Origin containing a path is invalid and rejected by Microsoft auth endpoints.

Verified against a real expired session: before, the console showed repeated "Refused to load ... owa.mail.runtime.js / owa.MsalAuth.js" and the window hung; after, zero resources are blocked and the app reaches the interactive login page.