### PR TITLE
Allow Outlook add-ins load and preserve Microsoft's CSP

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -410,27 +410,17 @@ if (!gotTheLock) {
 
             mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
                 const responseHeaders = { ...details.responseHeaders };
-                // Remove existing CSP, X-Frame-Options, and COOP/CORP to avoid conflicts
+                // Strip embedding-blocker headers but keep Microsoft's own CSP intact.
                 Object.keys(responseHeaders).forEach(key => {
                     const lowerKey = key.toLowerCase();
-                    if (lowerKey === 'content-security-policy' || 
-                        lowerKey === 'x-frame-options' || 
+                    if (lowerKey === 'x-frame-options' ||
                         lowerKey === 'cross-origin-opener-policy' ||
                         lowerKey === 'cross-origin-resource-policy') {
                         delete responseHeaders[key];
                     }
                 });
 
-                callback({
-                    responseHeaders: {
-                        ...responseHeaders,
-                        'Content-Security-Policy': [
-                            "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
-                            "frame-ancestors 'self' https://*.microsoft https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.msauth.net https://*.msftauth.net; " +
-                            "base-uri 'self';"
-                        ]
-                    }
-                });
+                callback({ responseHeaders });
             });
 
             mainWindow.loadURL(appConfig.url, {
@@ -694,14 +684,12 @@ if (!gotTheLock) {
             // Setup enhanced memory management
             setupEnhancedMemoryManagement();
 
-            // Enhanced security headers
             session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
                 const responseHeaders = { ...details.responseHeaders };
-                // Remove existing CSP, X-Frame-Options, and COOP/CORP to avoid conflicts
+                // Strip embedding-blocker headers but keep Microsoft's own CSP intact.
                 Object.keys(responseHeaders).forEach(key => {
                     const lowerKey = key.toLowerCase();
-                    if (lowerKey === 'content-security-policy' || 
-                        lowerKey === 'x-frame-options' || 
+                    if (lowerKey === 'x-frame-options' ||
                         lowerKey === 'cross-origin-opener-policy' ||
                         lowerKey === 'cross-origin-resource-policy') {
                         delete responseHeaders[key];
@@ -711,11 +699,6 @@ if (!gotTheLock) {
                 callback({
                     responseHeaders: {
                         ...responseHeaders,
-                        'Content-Security-Policy': [
-                            "default-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.microsoft https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.bing.com https://*.office.net https://*.msauth.net https://*.msftauth.net data: blob:; " +
-                            "frame-ancestors 'self' https://*.microsoft https://*.microsoft.com https://*.microsoftonline.com https://*.office.com https://*.office365.com https://*.live.com https://*.msauth.net https://*.msftauth.net; " +
-                            "base-uri 'self';"
-                        ],
                         'X-Content-Type-Options': ['nosniff']
                     }
                 });


### PR DESCRIPTION

Both onHeadersReceived handlers deleted the response Content-Security-Policy and replaced it with a hardcoded Microsoft-only allowlist. Outlook add-ins (e.g. Signitic) render their task pane in an iframe served from the add-in vendor's own domain, declared in the add-in manifest. Because the injected CSP had no frame-src directive, those iframes fell back to default-src, which only allowed Microsoft domains, so every third-party add-in was blocked and failed to load.

Add-in domains vary per tenant and per add-in and cannot be enumerated in a static allowlist, so no hardcoded policy can be compatible with all plugins. Microsoft's own CSP already allowlists the domains of installed add-ins.

Stop replacing the CSP: keep Microsoft's Content-Security-Policy untouched and only strip the headers that block embedding its content in the app window (X-Frame-Options, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy), which was the original intent. This also makes re-authentication more robust, since Microsoft's policy natively allows its own auth/runtime domains.